### PR TITLE
Update for ghc-7.10

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -39,8 +39,8 @@ module Control.Foldl (
     , scan
 
     -- * Folds
-    , mconcat
-    , foldMap
+    , Control.Foldl.mconcat
+    , Control.Foldl.foldMap
     , head
     , last
     , lastDef


### PR DESCRIPTION
The new Prelude includes `mconcat `and `foldMap`, so the export list was declared ambiguous. Fortunately, since there is no ambiguous use within the file, this expedient

    , Control.Foldl.mconcat
    , Control.Foldl.foldMap

seems to work fine.