### PR TITLE
Comonad instance for pure folds.

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -29,7 +29,8 @@ Library
         transformers >= 0.2.0.0  && < 0.5 ,
         vector       >= 0.7      && < 0.12,
         containers                  < 0.6,
-        profunctors                 < 5.2
+        profunctors                 < 5.2,
+        comonad      == 4.*
     Exposed-Modules:
         Control.Foldl,
         Control.Foldl.ByteString,

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -107,6 +107,7 @@ import Control.Applicative (Applicative(pure, (<*>)),liftA2)
 import Control.Foldl.Internal (Maybe'(..), lazy, Either'(..), hush)
 import Control.Monad ((>=>))
 import Control.Monad.Primitive (PrimMonad)
+import Control.Comonad
 import Data.Foldable (Foldable)
 import qualified Data.Foldable as F
 import Data.Functor.Constant (Constant(Constant, getConstant))
@@ -158,6 +159,13 @@ instance Functor (Fold a) where
 instance Profunctor Fold where
     lmap = premap
     rmap = fmap
+
+instance Comonad (Fold a) where
+    extract (Fold _ begin done) = done begin
+    {-#  INLINABLE extract #-}
+
+    duplicate (Fold step begin done) = Fold step begin (\x -> Fold step x done)
+    {-#  INLINABLE duplicate #-}
 
 instance Applicative (Fold a) where
     pure b    = Fold (\() _ -> ()) () (\() -> b)


### PR DESCRIPTION
A Comonad instance for the Fold type.

**extract** closes the Fold without feeding any input.

**duplicate** lets you keep feeding values to a fold even after passing it to some function that "closes" it.

Pure example:

    ghci> L.fold L.sum [1..100]
    5050
    ghci> L.fold (L.fold (duplicate L.sum) [1..50]) [51..100]
    5050

Example in IO:

    import System.IO
    import Control.Monad (foldM)
    import Control.Comonad
    import qualified Control.Foldl as L
    import qualified Pipes.Prelude as P
    import qualified Pipes.ByteString as B

    extract <$> foldM (\l f -> withFile f ReadMode $ L.purely P.fold (duplicate l) . B.fromHandle) 
                      L.list 
                      ["file1.txt", "file2.txt"]

This commit adds a new direct dependency on **comonad** (**foldl** already depends transitively on **comonad**, by way of **profunctors**).