### PR TITLE
Added "duplicateM" for monadic folds.

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -87,6 +87,7 @@ module Control.Foldl (
     , impurely
     , generalize
     , simplify
+    , duplicateM
     , _Fold1
     , premap
     , premapM
@@ -735,6 +736,16 @@ simplify (FoldM step begin done) = Fold step' begin' done'
     begin'    = runIdentity  begin
     done' x   = runIdentity (done x)
 {-# INLINABLE simplify #-}
+
+{-| Allows to continue feeding a 'FoldM' even after passing it to a function 
+that closes it.
+
+For pure 'Fold's, this is provided by the 'Control.Comonad.Comonad' instance.
+-}
+duplicateM :: Applicative m => FoldM m a b -> FoldM m a (FoldM m a b)
+duplicateM (FoldM step begin done) = 
+    FoldM step begin (\x -> pure (FoldM step (pure x) done))
+{-# INLINABLE duplicateM #-}
 
 {-| @_Fold1 step@ returns a new 'Fold' using just a step function that has the
 same type for the accumulator and the element. The result type is the


### PR DESCRIPTION
Hi,

Monadic folds can't be made instances of Comonad because they don't support a proper 'extract' function. But they can be duplicated in a similar manner to pure folds, and for similar purposes. I have added the 'duplicateM' function that does that.

Alternatively, they could be made instances of the [Data.Functor.Extend](http://hackage.haskell.org/package/semigroupoids-5.0.0.3/docs/Data-Functor-Extend.html#v:duplicated) (Comonad without extract) typeclass from the semigroupoids package. But adding that dependency for just one function is perhaps not worth it.