### PR TITLE
Add subfold and subfoldM

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -49,6 +49,8 @@ module Control.Foldl (
     , scan
 
     -- * Folds
+    , subfold
+    , subfoldM
     , Control.Foldl.mconcat
     , Control.Foldl.foldMap
     , head
@@ -447,6 +449,20 @@ scan (Fold step begin done) as = foldr cons nil as begin
     nil      x = done x:[]
     cons a k x = done x:(k $! step x a)
 {-# INLINE scan #-}
+
+-- | Fold over the elements inside a 'Foldable'.
+subfoldM :: (Monad m, Foldable f) => FoldM m a b -> FoldM m (f a) b
+subfoldM (FoldM step0 initial0 extract0) = FoldM step initial0 extract0
+  where
+    step = F.foldlM (\acc' x' -> acc' `seq` step0 acc' x')
+{-# INLINE subfoldM #-}
+
+-- | Fold over the elements inside a 'Foldable'.
+subfold :: (Foldable f) => Fold a b -> Fold (f a) b
+subfold (Fold step0 initial0 extract0) = Fold step initial0 extract0
+  where
+    step = F.foldl' (\acc' x' -> step0 acc' x')
+{-# INLINE subfold #-}
 
 -- | Fold all values within a container using 'mappend' and 'mempty'
 mconcat :: Monoid a => Fold a a


### PR DESCRIPTION
Is there some obvious reason why these don't exist (names are of course up for debate)? They seem remarkably useful.