### PR TITLE
Added maximumBy and minimumBy

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -64,7 +64,9 @@ module Control.Foldl (
     , sum
     , product
     , maximum
+    , maximumBy
     , minimum
+    , minimumBy
     , elem
     , notElem
     , find
@@ -549,10 +551,32 @@ maximum :: Ord a => Fold a (Maybe a)
 maximum = _Fold1 max
 {-# INLINABLE maximum #-}
 
+{-| Computes the maximum element with respect to the given comparison
+    function
+-}
+maximumBy :: (a -> a -> Ordering) -> Fold a (Maybe a)
+maximumBy cmp = _Fold1 max'
+  where 
+    max' x y = case cmp x y of
+        GT -> x
+        _  -> y
+{-# INLINABLE maximumBy #-}
+
 -- | Computes the minimum element
 minimum :: Ord a => Fold a (Maybe a)
 minimum = _Fold1 min
 {-# INLINABLE minimum #-}
+
+{-| Computes the minimum element with respect to the given comparison
+    function
+-}
+minimumBy :: (a -> a -> Ordering) -> Fold a (Maybe a)
+minimumBy cmp = _Fold1 min'
+  where 
+    min' x y = case cmp x y of
+        GT -> y
+        _  -> x
+{-# INLINABLE minimumBy #-}
 
 {-| @(elem a)@ returns 'True' if the container has an element equal to @a@,
     'False' otherwise


### PR DESCRIPTION
I recently needed the functionality of [`Data.List.maximumBy`](http://hackage.haskell.org/package/base-4.8.2.0/docs/Data-List.html#v:maximumBy). I actually got away with using tuple's `Ord` instance instead. But, I think it would be nice to have `maximumBy` and `minimumBy` in here.