### PR TITLE
Benchmarks (and some interesting results)

### DIFF
--- a/bench/benchmarks.hs
+++ b/bench/benchmarks.hs
@@ -1,0 +1,40 @@
+module Main (main) where
+
+import Control.Foldl
+import Criterion.Main
+import qualified Data.List
+import Prelude hiding (length, sum)
+import qualified Prelude
+
+main :: IO ()
+main = defaultMain
+  [ env (return [1..10000 :: Int]) $ \ns ->
+      bgroup "[1..10000 :: Int]"
+        [ bgroup "sum" $ map ($ ns)
+            [ bench "fold sum" .
+                whnf (fold sum)
+            , bench "foldM (generalize sum)" .
+                whnfIO . foldM (generalize sum)
+            , bench "Prelude.sum" .
+                whnf Prelude.sum
+            , bench "Data.List.foldl' (+) 0" .
+                whnf (Data.List.foldl' (+) 0)
+            ]
+        , bgroup "filtered" $ map ($ ns)
+            [ bench "fold (handles (filtered even) list)" .
+                nf (fold (handles (filtered even) list))
+            , bench "foldM (handlesM (filtered even) (generalize list))" .
+                nfIO . foldM (handlesM (filtered even) (generalize list))
+            , bench "filter even" .
+                nf (filter even)
+            ]
+        , bgroup "length" $ map ($ ns)
+            [ bench "fold length" .
+                whnf (fold length)
+            , bench "foldM (generalize length)" .
+                whnfIO . foldM (generalize length)
+            , bench "Prelude.length" .
+                whnf Prelude.length
+            ]
+        ]
+  ]

--- a/foldl.cabal
+++ b/foldl.cabal
@@ -40,3 +40,13 @@ Library
     Other-Modules:
         Control.Foldl.Internal
     GHC-Options: -O2 -Wall
+
+Benchmark benchmarks
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: bench
+    Main-Is: benchmarks.hs
+    Build-Depends:
+        base,
+        criterion,
+        foldl
+    GHC-Options: -O2 -Wall -rtsopts


### PR DESCRIPTION
Here are some results, compiled using GHC-8.0.1:

#### `sum`

```
benchmarking [1..1000 :: Int]/sum/fold sum
mean                 7.769 μs   (7.767 μs .. 7.774 μs)

benchmarking [1..1000 :: Int]/sum/foldM (generalize sum)
mean                 5.381 μs   (5.380 μs .. 5.382 μs)

benchmarking [1..1000 :: Int]/sum/Prelude.sum
mean                 30.23 μs   (30.22 μs .. 30.24 μs)

benchmarking [1..1000 :: Int]/sum/Data.List.foldl' (+) 0
mean                 12.86 μs   (12.85 μs .. 12.87 μs)
```

#### `filtered` / `filter`

```             
benchmarking [1..1000 :: Int]/filtered/fold (handles (filtered even) list)
mean                 26.44 μs   (26.42 μs .. 26.51 μs)

benchmarking [1..1000 :: Int]/filtered/foldM (handlesM (filtered even) (generalize list))
mean                 26.21 μs   (26.20 μs .. 26.22 μs)

benchmarking [1..1000 :: Int]/filtered/filter even
mean                 27.92 μs   (27.90 μs .. 27.99 μs)
```

#### `length`

```             
benchmarking [1..1000 :: Int]/length/fold length
mean                 7.654 μs   (7.616 μs .. 7.701 μs)

benchmarking [1..1000 :: Int]/length/foldM (generalize length)
mean                 3.454 μs   (3.453 μs .. 3.458 μs)

benchmarking [1..1000 :: Int]/length/Prelude.length
mean                 3.469 μs   (3.467 μs .. 3.471 μs)
```

Surprising to me was the (relatively) poor performance of the non-monadic folds in the `filtered` and `sum` benchmarks.

### Core

Here's the core for `fold sum`:

```
Rec {
-- RHS size: {terms: 46, types: 39, coercions: 0}
main_$s$wgo12
main_$s$wgo12 =
  \ sc_shTP sc1_shTO sc2_shTN ->
    case tagToEnum# (<=# sc1_shTO 0#) of _ {
      False ->
        case seq#
               (letrec {
                  go_agSN
                  go_agSN =
                    \ ds_agSO eta_B1 ->
                      case ds_agSO of _ {
                        [] -> eta_B1;
                        : y_agST ys_agSU ->
                          case eta_B1 of _ { I# x_agVg ->
                          case y_agST of _ { I# y1_agVk ->
                          go_agSN ys_agSU (I# (+# x_agVg y1_agVk))
                          }
                          }
                      }; } in
                go_agSN sc2_shTN $ssum1)
               sc_shTP
        of _ { (# ipv_agYF, ipv1_agYG #) ->
        main_$s$wgo12 ipv_agYF (-# sc1_shTO 1#) sc2_shTN
        };
      True -> (# sc_shTP, () #)
    }
end Rec }
```

And here's the core for `foldM (generalize sum)`:

```
Rec {
-- RHS size: {terms: 20, types: 17, coercions: 0}
main_$sgo
main_$sgo =
  \ sc_shTI sc1_shTH sc2_shTG ->
    case sc2_shTG of _ {
      [] -> (# sc_shTI, I# sc1_shTH #);
      : y_agST ys_agSU ->
        case y_agST of _ { I# y1_agVk ->
        main_$sgo sc_shTI (+# sc1_shTH y1_agVk) ys_agSU
        }
    }
end Rec }
```

I've already tried to fiddle around with `fold` and found some small effects in the `sum` benchmark after adding some bangs in the definition for `fold`.

The magic incantation that will seemingly make _any_ fold as fast as the respective monadic version is `-flate-dmd-anal`. Sadly it seems as if it will only go into effect when applied to the executable, not the library.

I think it should be investigated further anyway, and maybe recommended in the module docs. [It doesn't seem entirely unproblematic either](https://ghc.haskell.org/trac/ghc/wiki/LateDmd).