### PR TITLE
Add foldM for ByteString and Text

### DIFF
--- a/src/Control/Foldl/ByteString.hs
+++ b/src/Control/Foldl/ByteString.hs
@@ -3,6 +3,7 @@
 module Control.Foldl.ByteString (
     -- * Folding
       fold
+    , foldM
 
     -- * Folds
     , head
@@ -28,7 +29,7 @@ module Control.Foldl.ByteString (
     , module Data.Word
     ) where
 
-import Control.Foldl (Fold)
+import Control.Foldl (Fold, FoldM)
 import Control.Foldl.Internal (Maybe'(..), lazy, strict, Either'(..), hush)
 import qualified Control.Foldl as L
 import Data.ByteString (ByteString)
@@ -43,6 +44,17 @@ import Prelude hiding (
 fold :: Fold ByteString a -> Lazy.ByteString -> a
 fold (L.Fold step begin done) as = done (Lazy.foldlChunks step begin as)
 {-# INLINABLE fold #-}
+
+-- | Apply a strict monadic left 'FoldM' to a lazy bytestring
+foldM :: Monad m => FoldM m ByteString a -> Lazy.ByteString -> m a
+foldM (L.FoldM step begin done) as = do
+    x <- Lazy.foldlChunks step' begin as
+    done x
+  where
+    step' mx bs = do
+      x <- mx
+      step x bs
+{-# INLINABLE foldM #-}
 
 {-| Get the first byte of a byte stream or return 'Nothing' if the stream is
     empty

--- a/src/Control/Foldl/ByteString.hs
+++ b/src/Control/Foldl/ByteString.hs
@@ -53,7 +53,7 @@ foldM (L.FoldM step begin done) as = do
   where
     step' mx bs = do
       x <- mx
-      step x bs
+      x `seq` step x bs
 {-# INLINABLE foldM #-}
 
 {-| Get the first byte of a byte stream or return 'Nothing' if the stream is

--- a/src/Control/Foldl/Text.hs
+++ b/src/Control/Foldl/Text.hs
@@ -3,6 +3,7 @@
 module Control.Foldl.Text (
     -- * Folding
       fold
+    , foldM
 
     -- * Folds
     , head
@@ -27,7 +28,7 @@ module Control.Foldl.Text (
     , module Data.Text
     ) where
 
-import Control.Foldl (Fold)
+import Control.Foldl (Fold, FoldM)
 import Control.Foldl.Internal (Maybe'(..), lazy, strict, Either'(..), hush)
 import qualified Control.Foldl as L
 import Data.Text (Text)
@@ -40,6 +41,17 @@ import Prelude hiding (
 fold :: Fold Text a -> Lazy.Text -> a
 fold (L.Fold step begin done) as = done (Lazy.foldlChunks step begin as)
 {-# INLINABLE fold #-}
+
+-- | Apply a strict monadic left 'FoldM' to lazy text
+foldM :: Monad m => FoldM m Text a -> Lazy.Text -> m a
+foldM (L.FoldM step begin done) as = do
+    x <- Lazy.foldlChunks step' begin as
+    done x
+  where
+    step' mx bs = do
+      x <- mx
+      step x bs
+{-# INLINABLE foldM #-}
 
 {-| Get the first character of a text stream or return 'Nothing' if the stream
     is empty

--- a/src/Control/Foldl/Text.hs
+++ b/src/Control/Foldl/Text.hs
@@ -50,7 +50,7 @@ foldM (L.FoldM step begin done) as = do
   where
     step' mx bs = do
       x <- mx
-      step x bs
+      x `seq` step x bs
 {-# INLINABLE foldM #-}
 
 {-| Get the first character of a text stream or return 'Nothing' if the stream


### PR DESCRIPTION
This PR adds `foldM` for `ByteString` and `Text`.

It is sometimes useful to run monadic computation on lazy `ByteString` or `Text`:

```haskell
ghci> LT.foldM (L.mapM_ print) $ TL.fromChunks ["foo", "bar", "baz"]
"foo"
"bar"
"baz"
```