### PR TITLE
Use `vector-builder`.  Fixes #88

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,16 @@
 { mkDerivation, base, bytestring, comonad, containers
 , contravariant, hashable, mwc-random, primitive, profunctors
 , stdenv, text, transformers, unordered-containers, vector
+, vector-builder
 }:
 mkDerivation {
   pname = "foldl";
-  version = "1.2.4";
+  version = "1.2.5";
   src = ./.;
   libraryHaskellDepends = [
     base bytestring comonad containers contravariant hashable
     mwc-random primitive profunctors text transformers
-    unordered-containers vector
+    unordered-containers vector vector-builder
   ];
   description = "Composable, streaming, and efficient left folds";
   license = stdenv.lib.licenses.bsd3;

--- a/foldl.cabal
+++ b/foldl.cabal
@@ -37,7 +37,8 @@ Library
         hashable                    < 1.3 ,
         contravariant               < 1.5 ,
         profunctors                 < 5.3 ,
-        comonad      >= 4.0      && < 6
+        comonad      >= 4.0      && < 6   ,
+        vector-builder              < 0.4
     Exposed-Modules:
         Control.Foldl,
         Control.Foldl.ByteString,


### PR DESCRIPTION
This improves the performance of the `vector` utility and allows it to become a
pure `Fold`