### PR TITLE
Refactor Nix code

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,18 +1,29 @@
-{ mkDerivation, base, bytestring, comonad, containers
-, contravariant, criterion, hashable, mwc-random, primitive
-, profunctors, semigroups, stdenv, text, transformers
-, unordered-containers, vector, vector-builder
-}:
-mkDerivation {
-  pname = "foldl";
-  version = "1.4.1";
-  src = ./.;
-  libraryHaskellDepends = [
-    base bytestring comonad containers contravariant hashable
-    mwc-random primitive profunctors semigroups text transformers
-    unordered-containers vector vector-builder
-  ];
-  benchmarkHaskellDepends = [ base criterion ];
-  description = "Composable, streaming, and efficient left folds";
-  license = stdenv.lib.licenses.bsd3;
-}
+let
+  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
+
+    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
+
+    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
+  };
+
+  readDirectory = import ./nix/readDirectory.nix;
+
+  config = {
+    packageOverrides = pkgs: {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = readDirectory ./nix;
+      };
+    };
+  };
+
+  pkgs =
+    import nixpkgs { inherit config; };
+
+in
+  { inherit (pkgs.haskellPackages) foldl;
+
+    shell = (pkgs.haskell.lib.doBenchmark pkgs.haskellPackages.foldl).env;
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 fixed-output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = outputSha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+      
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/nix/readDirectory.nix
+++ b/nix/readDirectory.nix
@@ -1,0 +1,14 @@
+directory:
+
+haskellPackagesNew: haskellPackagesOld:
+  let
+    haskellPaths = builtins.attrNames (builtins.readDir directory);
+
+    toKeyVal = file: {
+      name  = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+      value = haskellPackagesNew.callPackage (directory + "/${file}") { };
+    };
+
+  in
+    builtins.listToAttrs (map toKeyVal haskellPaths)

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, comonad, containers
+, contravariant, criterion, hashable, mwc-random, primitive
+, profunctors, semigroups, stdenv, text, transformers
+, unordered-containers, vector, vector-builder
+}:
+mkDerivation {
+  pname = "foldl";
+  version = "1.4.1";
+  src = ./..;
+  libraryHaskellDepends = [
+    base bytestring comonad containers contravariant hashable
+    mwc-random primitive profunctors semigroups text transformers
+    unordered-containers vector vector-builder
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  description = "Composable, streaming, and efficient left folds";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -2,4 +2,4 @@ let
   default = import ./default.nix;
 
 in
-  { inherit (default) turtle; }
+  { inherit (default) foldl; }

--- a/release.nix
+++ b/release.nix
@@ -1,30 +1,5 @@
-# You can build this repository using Nix by running:
-#
-#     $ nix-build -A foldl release.nix
-#
-# You can also open up this repository inside of a Nix shell by running:
-#
-#     $ nix-shell -A foldl.env release.nix
-#
-# ... and then Nix will supply the correct Haskell development environment for
-# you
 let
-  config = {
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          foldl = haskellPackagesNew.callPackage ./default.nix { };
-
-          # `vector-builder`'s test suite depends on `foldl`
-          vector-builder = pkgs.haskell.lib.dontCheck haskellPackagesOld.vector-builder;
-        };
-      };
-    };
-  };
-
-  pkgs =
-    import <nixpkgs> { inherit config; };
+  default = import ./default.nix;
 
 in
-  { foldl = pkgs.haskellPackages.foldl;
-  }
+  { inherit (default) turtle; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).foldl.env
+(import ./default.nix).shell


### PR DESCRIPTION
This pins `nipxkgs` and also uses `readDirectory` to simplify testing changes
to dependencies