### PR TITLE
Change mean to be numerically stable.

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -626,7 +626,7 @@ mean :: Fractional a => Fold a a
 mean = Fold step begin done
   where
     begin = Pair 0 0
-    step (Pair x n) y = Pair ((x * n + y) / (n + 1)) (n + 1)
+    step (Pair x n) y = let n' = n+1 in Pair (x + (y - x) /n') n'
     done (Pair x _) = x
 {-# INLINABLE mean #-}
 


### PR DESCRIPTION
The original version of mean is not numerically stable since the product x*n actually calculates the full sum in each update and it can be very large compared to y. The proposed version does not suffer from this problem. See [https://diego.assencio.com/?index=c34d06f4f4de2375658ed41f70177d59](url) for details.