### PR TITLE
Properly signal supported base versions

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -24,7 +24,7 @@ Source-Repository head
 Library
     HS-Source-Dirs: src
     Build-Depends:
-        base         >= 4.5      && < 5   ,
+        base         >= 4.8      && < 5   ,
         bytestring   >= 0.9.2.1  && < 0.11,
         mwc-random   >= 0.13.1.0 && < 0.15,
         primitive                   < 0.7 ,


### PR DESCRIPTION
According to #107 support for base < 4.8 was dropped, but the cabal metadata
wasn't updated accordingly to reflect this

I've already revised the affected versions on Hackage as they were propagating build-plan failures into reverse dependencies

- https://hackage.haskell.org/package/foldl-1.4.1/revisions/
- https://hackage.haskell.org/package/foldl-1.4.2/revisions/
- https://hackage.haskell.org/package/foldl-1.4.3/revisions/