### PR TITLE
Add exHalt, exHalt_, exSkip, exSkip_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+
+* Add `exHalt`, `exHalt_`, `exSkip`, `exSkip_`
+* Add dependency on `safe-exceptions`
+
 1.4.5
 
 * Increase upper bound on `containers`

--- a/foldl.cabal
+++ b/foldl.cabal
@@ -39,7 +39,8 @@ Library
         profunctors                 < 5.4 ,
         semigroupoids >= 1.0     && < 5.4 ,
         comonad      >= 4.0      && < 6   ,
-        vector-builder              < 0.4
+        vector-builder              < 0.4 ,
+        safe-exceptions
     Exposed-Modules:
         Control.Foldl,
         Control.Foldl.ByteString,

--- a/nix/foldl.nix
+++ b/nix/foldl.nix
@@ -1,7 +1,7 @@
 { mkDerivation, base, bytestring, comonad, containers
 , contravariant, criterion, hashable, mwc-random, primitive
-, profunctors, semigroupoids, semigroups, stdenv, text
-, transformers, unordered-containers, vector, vector-builder
+, profunctors, safe-exceptions, semigroupoids, semigroups, stdenv
+, text, transformers, unordered-containers, vector, vector-builder
 }:
 mkDerivation {
   pname = "foldl";
@@ -9,8 +9,9 @@ mkDerivation {
   src = ./..;
   libraryHaskellDepends = [
     base bytestring comonad containers contravariant hashable
-    mwc-random primitive profunctors semigroupoids semigroups text
-    transformers unordered-containers vector vector-builder
+    mwc-random primitive profunctors safe-exceptions semigroupoids
+    semigroups text transformers unordered-containers vector
+    vector-builder
   ];
   benchmarkHaskellDepends = [ base criterion ];
   description = "Composable, streaming, and efficient left folds";


### PR DESCRIPTION
If you have a monadic fold where `IO` is the monad, it seems to me that if one of the fold's steps produces an exception, you may not want to lose the result thus far from the previous steps that succeeded.

Here are some functions that recover from errors: `exHalt` and `exHalt_` stop at the first exception and return the state, whereas `exSkip` and `exSkip_` keep going and apply as many successful steps as possible. The `exHalt_` and `exSkip_` folds return only the result, whereas `exHalt` and `exSkip` also return any exceptions that were thrown.

I'm not sure if `safe-exceptions` is a dependency you want to incur here, or whether the notion of early termination of folds quite fits into the *spirit* of the `foldl` package - What do you think?