### PR TITLE
Support GHC 8.8

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -36,7 +36,7 @@ Library
         hashable                    < 1.3 ,
         contravariant               < 1.6 ,
         semigroups   >= 0.17     && < 1.19,
-        profunctors                 < 5.4 ,
+        profunctors                 < 5.5 ,
         semigroupoids >= 1.0     && < 5.4 ,
         comonad      >= 4.0      && < 6   ,
         vector-builder              < 0.4


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.