### PR TITLE
Add documentation benchmarks

### DIFF
--- a/bench/benchmarks.hs
+++ b/bench/benchmarks.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Main (main) where
 
 import Control.Foldl hiding (map)
@@ -5,6 +7,7 @@ import Criterion.Main
 import qualified Data.List
 import Prelude hiding (length, sum)
 import qualified Prelude
+import qualified Data.Foldable as Foldable
 
 main :: IO ()
 main = defaultMain
@@ -36,5 +39,36 @@ main = defaultMain
             , bench "Prelude.length" .
                 whnf Prelude.length
             ]
+        , bgroup "sumAndLength" $ map ($ ns)
+            [ bench "naive sumAndLength" .
+                whnf sumAndLength
+            , bench "foldl' sumAndLength" .
+                whnf sumAndLength'
+            , bench "strict pair sumAndLength" .
+                whnf sumAndLength_Pair
+            , bench "foldl sumAndLength" .
+                whnf sumAndLength_foldl
+            ]
         ]
   ]
+
+
+sumAndLength :: Num a => [a] -> (a, Int)
+sumAndLength xs = (Prelude.sum xs, Prelude.length xs)
+
+sumAndLength' :: Num a => [a] -> (a, Int)
+sumAndLength' xs = Foldable.foldl' step (0, 0) xs
+  where
+    step (x, y) n = (x + n, y + 1)
+
+data Pair a b = Pair !a !b
+
+sumAndLength_Pair :: Num a => [a] -> (a, Int)
+sumAndLength_Pair xs = done (Foldable.foldl' step (Pair 0 0) xs)
+  where
+    step (Pair x y) n = Pair (x + n) (y + 1)
+
+    done (Pair x y) = (x, y)
+
+sumAndLength_foldl :: Num a => [a] -> (a, Int)
+sumAndLength_foldl = fold ((,) <$> sum <*> length)

--- a/bench/benchmarks.hs
+++ b/bench/benchmarks.hs
@@ -41,13 +41,13 @@ main = defaultMain
             ]
         , bgroup "sumAndLength" $ map ($ ns)
             [ bench "naive sumAndLength" .
-                whnf sumAndLength
+                nf sumAndLength
             , bench "foldl' sumAndLength" .
-                whnf sumAndLength'
+                nf sumAndLength'
             , bench "strict pair sumAndLength" .
-                whnf sumAndLength_Pair
+                nf sumAndLength_Pair
             , bench "foldl sumAndLength" .
-                whnf sumAndLength_foldl
+                nf sumAndLength_foldl
             ]
         ]
   ]

--- a/foldl.cabal
+++ b/foldl.cabal
@@ -58,4 +58,4 @@ Benchmark benchmarks
         base,
         criterion,
         foldl
-    GHC-Options: -O2 -Wall -rtsopts
+    GHC-Options: -O2 -Wall -rtsopts -rtsopts -with-rtsopts=-T


### PR DESCRIPTION
This adds the `sumAndLength` example from the documentation into the benchmarks. If run as follows `cabal new-run bench:benchmarks -- --regress allocated:iters` the relevant part of the output for the new benchmarks on my machine gives:
```

benchmarking [1..10000 :: Int]/sumAndLength/naive sumAndLength
time                 39.94 μs   (39.74 μs .. 40.20 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 39.83 μs   (39.72 μs .. 40.03 μs)
std dev              508.2 ns   (333.0 ns .. 737.7 ns)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              103.989    (103.827 .. 104.187)
  y                  2561.595   (2278.120 .. 2860.909)

benchmarking [1..10000 :: Int]/sumAndLength/foldl' sumAndLength
time                 43.58 μs   (43.09 μs .. 44.10 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 43.81 μs   (43.33 μs .. 44.78 μs)
std dev              2.167 μs   (1.148 μs .. 3.424 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              320040.025 (320039.820 .. 320040.262)
  y                  2541.189   (2234.370 .. 2852.427)
variance introduced by outliers: 55% (severely inflated)

benchmarking [1..10000 :: Int]/sumAndLength/strict pair sumAndLength
time                 24.93 μs   (24.90 μs .. 24.98 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 24.94 μs   (24.91 μs .. 24.99 μs)
std dev              122.7 ns   (69.71 ns .. 220.2 ns)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              55.992     (55.891 .. 56.108)
  y                  2545.524   (2273.092 .. 2824.400)

benchmarking [1..10000 :: Int]/sumAndLength/foldl sumAndLength
time                 62.93 μs   (61.92 μs .. 64.73 μs)
                     0.992 R²   (0.982 R² .. 0.998 R²)
mean                 64.55 μs   (63.04 μs .. 68.12 μs)
std dev              7.298 μs   (3.832 μs .. 12.89 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              560023.960 (560023.689 .. 560024.299)
  y                  2571.073   (2264.867 .. 2932.905)
variance introduced by outliers: 86% (severely inflated)

```

Increasing the output size gives an increased memory footprint on the foldl version and suggests that somewhere there is a space/memory leak. This also indicates the documentation is not very accurate (unless one compiles without optimizations) as Haskell does a very good job at optimizing the naive version.