### PR TITLE
Add test-suite for doctest, fix failing doctests

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -59,3 +59,12 @@ Benchmark benchmarks
         criterion,
         foldl
     GHC-Options: -O2 -Wall -rtsopts -rtsopts -with-rtsopts=-T
+
+Test-Suite doctest
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: test
+    Main-Is: doctest.hs
+    Build-Depends:
+        base,
+        doctest >= 0.16
+    GHC-Options: -threaded

--- a/nix/foldl.nix
+++ b/nix/foldl.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, bytestring, comonad, containers
-, contravariant, criterion, hashable, mwc-random, primitive
-, profunctors, semigroupoids, semigroups, stdenv, text
+, contravariant, criterion, doctest, hashable, mwc-random
+, primitive, profunctors, semigroupoids, semigroups, stdenv, text
 , transformers, unordered-containers, vector, vector-builder
 }:
 mkDerivation {
@@ -12,6 +12,7 @@ mkDerivation {
     mwc-random primitive profunctors semigroupoids semigroups text
     transformers unordered-containers vector vector-builder
   ];
+  testHaskellDepends = [ base doctest ];
   benchmarkHaskellDepends = [ base criterion ];
   description = "Composable, streaming, and efficient left folds";
   license = stdenv.lib.licenses.bsd3;

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -194,6 +194,22 @@ import qualified VectorBuilder.Builder
 import qualified VectorBuilder.Vector
 import qualified Data.Semigroupoid
 
+{- $setup
+
+>>> import qualified Control.Foldl as L
+
+>>> _2 f (x, y) = fmap (\i -> (x, i)) (f y)
+
+>>> :{
+>>> _Just = let maybeEither Nothing = Left Nothing
+>>>             maybeEither (Just x) = Right x
+>>>         in Control.Foldl.Optics.prism Just maybeEither
+>>> :}
+
+>>> both f (x, y) = (,) <$> f x <*> f y
+
+-}
+
 {-| Efficient representation of a left fold that preserves the fold's step
     function, initial accumulator, and extraction function
 
@@ -1104,12 +1120,12 @@ _Fold1 step = Fold step_ Nothing' lazy
 
 {-| @(premap f folder)@ returns a new 'Fold' where f is applied at each step
 
-> fold (premap f folder) list = fold folder (map f list)
+> fold (premap f folder) list = fold folder (List.map f list)
 
->>> fold (premap Sum mconcat) [1..10]
+>>> fold (premap Sum L.mconcat) [1..10]
 Sum {getSum = 55}
 
->>> fold mconcat (map Sum [1..10])
+>>> fold L.mconcat (List.map Sum [1..10])
 Sum {getSum = 55}
 
 > premap id = id
@@ -1218,7 +1234,7 @@ type Handler a b =
 >>> fold (handles (filtered even) sum) [1..10]
 30
 
->>> fold (handles _2 mconcat) [(1,"Hello "),(2,"World"),(3,"!")]
+>>> fold (handles _2 L.mconcat) [(1,"Hello "),(2,"World"),(3,"!")]
 "Hello World!"
 
 > handles id = id
@@ -1333,7 +1349,7 @@ folded k ts = contramap (\_ -> ()) (F.traverse_ k ts)
 >>> fold (handles (filtered even) sum) [1..10]
 30
 
->>> foldM (handlesM (filtered even) (mapM_ print)) [1..10]
+>>> foldM (handlesM (filtered even) (L.mapM_ print)) [1..10]
 2
 4
 6

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -1,0 +1,4 @@
+import Test.DocTest
+
+main :: IO ()
+main = doctest ["-isrc", "src/Control/Foldl.hs", "src/Control/Scanl.hs"]


### PR DESCRIPTION
I set up a test-suite to run doctest while working on #140 and figured it might as well be part of the package?

I've also fixed a few things that doctest revealed to be failing. These fall into two categories:

- Names overlapping with `Prelude` that needed to be qualified
- References to things defined in `lens`; since that isn't a dependency, I just added a small `$setup` block which defines suitable replacements.