### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -35,11 +35,13 @@ Library
         unordered-containers        < 0.3 ,
         hashable                    < 1.4 ,
         contravariant               < 1.6 ,
-        semigroups   >= 0.17     && < 1.20,
         profunctors                 < 5.6 ,
         semigroupoids >= 1.0     && < 5.4 ,
         comonad      >= 4.0      && < 6   ,
         vector-builder              < 0.4
+    if impl(ghc < 8.0)
+        Build-Depends:
+            semigroups   >= 0.17 && < 1.20
     Exposed-Modules:
         Control.Foldl,
         Control.Foldl.ByteString,


### PR DESCRIPTION
They are not needed on newer GHC.