### PR TITLE
Reimplement immutable vector fold without builder

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -37,8 +37,7 @@ Library
         contravariant               < 1.6 ,
         profunctors                 < 5.6 ,
         semigroupoids >= 1.0     && < 5.4 ,
-        comonad      >= 4.0      && < 6   ,
-        vector-builder              < 0.4
+        comonad      >= 4.0      && < 6
     if impl(ghc < 8.0)
         Build-Depends:
             semigroups   >= 0.17 && < 1.20
@@ -50,6 +49,8 @@ Library
     Other-Modules:
         Control.Foldl.Optics
         Control.Foldl.Internal
+        Control.Foldl.Util.Vector
+        Control.Foldl.Util.MVector
     GHC-Options: -O2 -Wall
     Default-Language: Haskell2010
 

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -197,9 +197,8 @@ import qualified Data.Map.Strict             as Map
 import qualified Data.HashMap.Strict         as HashMap
 import qualified Data.HashSet                as HashSet
 import qualified Data.Vector.Generic         as V
+import qualified Control.Foldl.Util.Vector   as V
 import qualified Data.Vector.Generic.Mutable as M
-import qualified VectorBuilder.Builder
-import qualified VectorBuilder.Vector
 import qualified Data.Semigroupoid
 
 {- $setup
@@ -1000,13 +999,7 @@ foldByKeyHashMap f = case f of
 
 -- | Fold all values into a vector
 vector :: Vector v a => Fold a (v a)
-vector = Fold step begin done
-  where
-    begin = VectorBuilder.Builder.empty
-
-    step x a = x <> VectorBuilder.Builder.singleton a
-
-    done = VectorBuilder.Vector.build
+vector = V.fromReverseListN <$> length <*> revList
 {-# INLINABLE vector #-}
 
 maxChunkSize :: Int

--- a/src/Control/Foldl/Util/MVector.hs
+++ b/src/Control/Foldl/Util/MVector.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE BangPatterns #-}
+module Control.Foldl.Util.MVector
+where
+
+import Data.Vector.Generic.Mutable
+import Control.Monad.ST
+
+
+{-# INLINE writeListInReverseOrderStartingFrom #-}
+writeListInReverseOrderStartingFrom :: MVector v a => v s a -> Int -> [a] -> ST s ()
+writeListInReverseOrderStartingFrom v = let
+  loop !index list = case list of
+    h : t -> do
+      unsafeWrite v index h
+      loop (pred index) t
+    _ -> return ()
+  in loop

--- a/src/Control/Foldl/Util/Vector.hs
+++ b/src/Control/Foldl/Util/Vector.hs
@@ -1,0 +1,27 @@
+{-|
+General utilities for immutable vectors.
+-}
+{-# LANGUAGE RankNTypes #-}
+module Control.Foldl.Util.Vector where
+
+import Data.Vector.Generic
+import Control.Monad.ST
+import qualified Data.Vector.Generic.Mutable as M
+import qualified Control.Foldl.Util.MVector as M
+
+
+{-|
+>>> fromReverseListN 3 [1,2,3] :: Data.Vector.Vector Int
+[3,2,1]
+-}
+{-# INLINE fromReverseListN #-}
+fromReverseListN :: Vector v a => Int -> [a] -> v a
+fromReverseListN size list =
+  initialized size $ \ mv -> M.writeListInReverseOrderStartingFrom mv (pred size) list
+
+{-# INLINE initialized #-}
+initialized :: Vector v a => Int -> (forall s. Mutable v s a -> ST s ()) -> v a
+initialized size initialize = runST $ do
+  mv <- M.unsafeNew size
+  initialize mv
+  freeze mv

--- a/src/Control/Foldl/Util/Vector.hs
+++ b/src/Control/Foldl/Util/Vector.hs
@@ -24,4 +24,4 @@ initialized :: Vector v a => Int -> (forall s. Mutable v s a -> ST s ()) -> v a
 initialized size initialize = runST $ do
   mv <- M.unsafeNew size
   initialize mv
-  freeze mv
+  unsafeFreeze mv


### PR DESCRIPTION
Builder provides more features than we need for which we have to pay with performance. In this PR I'm replacing it altogether with a simple and efficient strategy.

The strategy is to build it in two passes:
1. Accumulate a reverse list and its length.
2. Allocate a vector of that length and traverse it in reverse order populating it with elements of the list.

Performance of this function should now be comparable to the `list` fold.