### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -25,7 +25,7 @@ Library
     HS-Source-Dirs: src
     Build-Depends:
         base         >= 4.8      && < 5   ,
-        bytestring   >= 0.9.2.1  && < 0.11,
+        bytestring   >= 0.9.2.1  && < 0.12,
         mwc-random   >= 0.13.1.0 && < 0.16,
         primitive                   < 0.8 ,
         text         >= 0.11.2.0 && < 1.3 ,


### PR DESCRIPTION
Tested using 
```cabal
packages: .

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1
```