### PR TITLE
Data.Functor.Extend instances for Fold and FoldM.

### DIFF
--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -160,6 +160,7 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid hiding ((<>))
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroupoid (Semigroupoid)
+import Data.Functor.Extend (Extend(..))
 import Data.Profunctor
 import Data.Sequence ((|>))
 import Data.Vector.Generic (Vector, Mutable)
@@ -259,6 +260,10 @@ instance Applicative (Fold a) where
             done (Pair xL xR) = doneL xL (doneR xR)
         in  Fold step begin done
     {-# INLINE (<*>) #-}
+
+instance Extend (Fold a) where
+    duplicated = duplicate
+    {-# INLINE duplicated #-}
 
 instance Semigroup b => Semigroup (Fold a b) where
     (<>) = liftA2 (<>)
@@ -395,6 +400,10 @@ instance Applicative m => Applicative (FoldM m a) where
             done (Pair xL xR) = doneL xL <*> doneR xR
         in  FoldM step begin done
     {-# INLINE (<*>) #-}
+
+instance Monad m => Extend (FoldM m a) where
+    duplicated = duplicateM
+    {-# INLINE duplicated #-}
 
 instance Functor m => Profunctor (FoldM m) where
     rmap = fmap


### PR DESCRIPTION
Because `Fold` is a `Comonad`, it's also an instance of [`Extend`](http://hackage.haskell.org/package/semigroupoids-5.3.5/docs/Data-Functor-Extend.html#v:duplicated) (from "semigroupoids").

`FoldM` is not a `Comonad` because we cant define `extract`, but it can be given an `Extend` instance. The implementation of [`duplicated`](http://hackage.haskell.org/package/semigroupoids-5.3.5/docs/Data-Functor-Extend.html#v:duplicated) is the same as the already-existing function `duplicateM`.