### PR TITLE
Depend on random directly instead of mwc-random

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -26,7 +26,7 @@ Library
     Build-Depends:
         base         >= 4.8      && < 5   ,
         bytestring   >= 0.9.2.1  && < 0.12,
-        mwc-random   >= 0.13.1.0 && < 0.16,
+        random       >= 1.2      && < 1.3 ,
         primitive                   < 0.8 ,
         text         >= 0.11.2.0 && < 1.3 ,
         transformers >= 0.2.0.0  && < 0.6 ,


### PR DESCRIPTION
`foldl` depends on `mwc-random`, but uses only `uniformR`, which is actually a re-export from `random`. Eliminating the middleman saves us three transitive dependencies: `mwc-random` itself + `math-functions` + `data-default-class`.